### PR TITLE
feat: contextual duplicate detection and import UX improvements

### DIFF
--- a/app/controllers/operations_controller.rb
+++ b/app/controllers/operations_controller.rb
@@ -105,31 +105,40 @@ class OperationsController < ApplicationController
         op_match(op, is_probable ? 'probable' : 'possible')
       end
 
-      # Contextual: same month, same amount OR same category OR similar note
-      l3_parts = ["amount = ?"]
-      l3_binds = [amount]
-      if row[:type_id].present?
-        l3_parts << "type_id = ?"
-        l3_binds << row[:type_id].to_i
-      end
-      if key
-        l3_parts << "note LIKE ?"
-        l3_binds << "%#{key}%"
-      end
-      existing_ids = match_list.map { |m| m[:id] }
-      l3_query = Operation.includes(:type, :user)
-        .where("year = ? AND month = ? AND (#{l3_parts.join(' OR ')})", date.year, date.month, *l3_binds)
-      l3_query = l3_query.where.not(id: existing_ids) if existing_ids.any?
-      match_list += l3_query.to_a.map { |op| op_match(op, 'contextual') }
-
       next if match_list.empty?
 
-      kind_order = { 'probable' => 0, 'possible' => 1, 'contextual' => 2 }
-      match_list.sort_by! { |m| kind_order.fetch(m[:kind].to_s, 99) }
+      match_list.sort_by! { |m| m[:kind] == 'probable' ? 0 : 1 }
 
       { index: i, matches: match_list }
     end
     render json: matches
+  end
+
+  # POST /operations/check_contextual.json
+  def check_contextual
+    row = params.require(:row).permit(:date, :amount, :type_id, :note)
+    date = Date.parse(row[:date].to_s) rescue nil
+    return render json: [] unless date
+    amount = row[:amount].to_f
+    key = row[:note].present? ? row[:note].to_s.split(/\s+/).select { |w| w.length >= 4 }.max_by(&:length) : nil
+
+    l3_parts = ["amount = ?"]
+    l3_binds = [amount]
+    if row[:type_id].present?
+      l3_parts << "type_id = ?"
+      l3_binds << row[:type_id].to_i
+    end
+    if key
+      l3_parts << "note REGEXP ?"
+      l3_binds << "[[:<:]]#{Regexp.escape(key)}[[:>:]]"
+    end
+    exclude_ids = Array(params[:exclude_ids]).map(&:to_i)
+
+    query = Operation.includes(:type, :user)
+      .where("year = ? AND month = ? AND (#{l3_parts.join(' OR ')})", date.year, date.month, *l3_binds)
+    query = query.where.not(id: exclude_ids) if exclude_ids.any?
+
+    render json: query.to_a.map { |op| op_match(op, 'contextual') }
   end
 
   # POST /operations/extract.json

--- a/app/controllers/withdrawals_controller.rb
+++ b/app/controllers/withdrawals_controller.rb
@@ -55,27 +55,36 @@ class WithdrawalsController < ApplicationController
         wd_match(wd, is_probable ? 'probable' : 'possible')
       end
 
-      # Contextual: same month, same amount OR similar note
-      l3_parts = ["amount = ?"]
-      l3_binds = [amount]
-      if key
-        l3_parts << "note LIKE ?"
-        l3_binds << "%#{key}%"
-      end
-      existing_ids = match_list.map { |m| m[:id] }
-      l3_query = Withdrawal.includes(:user)
-        .where("YEAR(date) = ? AND MONTH(date) = ? AND (#{l3_parts.join(' OR ')})", date.year, date.month, *l3_binds)
-      l3_query = l3_query.where.not(id: existing_ids) if existing_ids.any?
-      match_list += l3_query.to_a.map { |wd| wd_match(wd, 'contextual') }
-
       next if match_list.empty?
 
-      kind_order = { 'probable' => 0, 'possible' => 1, 'contextual' => 2 }
-      match_list.sort_by! { |m| kind_order.fetch(m[:kind].to_s, 99) }
+      match_list.sort_by! { |m| m[:kind] == 'probable' ? 0 : 1 }
 
       { index: i, matches: match_list }
     end
     render json: matches
+  end
+
+  # POST /withdrawals/check_contextual.json
+  def check_contextual
+    row = params.require(:row).permit(:date, :amount, :note)
+    date = Date.parse(row[:date].to_s) rescue nil
+    return render json: [] unless date
+    amount = row[:amount].to_f
+    key = row[:note].present? ? row[:note].to_s.split(/\s+/).select { |w| w.length >= 4 }.max_by(&:length) : nil
+
+    l3_parts = ["amount = ?"]
+    l3_binds = [amount]
+    if key
+      l3_parts << "note REGEXP ?"
+      l3_binds << "[[:<:]]#{Regexp.escape(key)}[[:>:]]"
+    end
+    exclude_ids = Array(params[:exclude_ids]).map(&:to_i)
+
+    query = Withdrawal.includes(:user)
+      .where("YEAR(date) = ? AND MONTH(date) = ? AND (#{l3_parts.join(' OR ')})", date.year, date.month, *l3_binds)
+    query = query.where.not(id: exclude_ids) if exclude_ids.any?
+
+    render json: query.to_a.map { |wd| wd_match(wd, 'contextual') }
   end
 
   # GET /withdrawals/1.json

--- a/app/frontend/__tests__/ImportView.test.ts
+++ b/app/frontend/__tests__/ImportView.test.ts
@@ -235,8 +235,8 @@ describe('ImportView', () => {
       const vm = wrapper.vm as any
       const row = makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE })
       vm.rows.push(row)
-      vm.openDuplicateModal('operation', row)
-      await nextTick()
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
       expect(vm.modalEntry).not.toBeNull()
       await vm.checkDuplicates()
       await nextTick()
@@ -249,8 +249,8 @@ describe('ImportView', () => {
       const vm = wrapper.vm as any
       const row = makeRow('Internal transfer', { duplicates: [{ ...DUPLICATE, kind: 'possible' }], selectedDuplicate: DUPLICATE })
       vm.skippedRows.push(row)
-      vm.openDuplicateModal('operation', row)
-      await nextTick()
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
       expect(vm.modalEntry).not.toBeNull()
       await vm.checkDuplicates()
       await nextTick()
@@ -263,8 +263,8 @@ describe('ImportView', () => {
       const vm = wrapper.vm as any
       const row = makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE })
       vm.rows.push(row)
-      vm.openDuplicateModal('operation', row)
-      await nextTick()
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
       expect(vm.modalEntry).not.toBeNull()
       await vm.checkDuplicates()
       await nextTick()
@@ -388,8 +388,8 @@ describe('ImportView', () => {
       const vm = wrapper.vm as any
       const secondMatch: DuplicateMatch = { ...DUPLICATE, id: 88, kind: 'possible' }
       const row = makeRow('Esselunga', { duplicates: [DUPLICATE, secondMatch], selectedDuplicate: DUPLICATE })
-      vm.openDuplicateModal('operation', row)
-      await nextTick()
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
       vm.selectDuplicate(secondMatch)
       expect(row.selectedDuplicate?.id).toBe(88)
       expect(row.updateExisting).toBe(true)
@@ -404,8 +404,8 @@ describe('ImportView', () => {
       const wrapper = await mountView()
       const vm = wrapper.vm as any
       const row = makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE })
-      vm.openDuplicateModal('operation', row)
-      await nextTick()
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
       expect(vm.modalEntry).not.toBeNull()
       expect(vm.modalEntry.kind).toBe('operation')
       expect(vm.modalEntry.row).toEqual(row)
@@ -415,8 +415,8 @@ describe('ImportView', () => {
       const wrapper = await mountView()
       const vm = wrapper.vm as any
       const row = makeWdRow('ATM', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE })
-      vm.openDuplicateModal('withdrawal', row)
-      await nextTick()
+      await vm.openDuplicateModal('withdrawal', row)
+      await flushPromises()
       expect(vm.modalEntry).not.toBeNull()
       expect(vm.modalEntry.kind).toBe('withdrawal')
     })
@@ -424,8 +424,8 @@ describe('ImportView', () => {
     it('clears modalEntry when closeDuplicateModal is called', async () => {
       const wrapper = await mountView()
       const vm = wrapper.vm as any
-      vm.openDuplicateModal('operation', makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE }))
-      await nextTick()
+      await vm.openDuplicateModal('operation', makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE }))
+      await flushPromises()
       vm.closeDuplicateModal()
       await nextTick()
       expect(vm.modalEntry).toBeNull()
@@ -435,11 +435,34 @@ describe('ImportView', () => {
       const wrapper = await mountView()
       const vm = wrapper.vm as any
       const row = makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE, updateExisting: false })
-      vm.openDuplicateModal('operation', row)
-      await nextTick()
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
       row.updateExisting = true
       vm.onOpUpdateExistingChange(row)
       expect(row.selected).toBe(true)
+    })
+
+    it('calls check_contextual and populates contextualMatches after opening', async () => {
+      const contextual: DuplicateMatch = { ...DUPLICATE, id: 99, kind: 'contextual' }
+      mocks.apiPost.mockResolvedValue([contextual])
+      const wrapper = await mountView()
+      const vm = wrapper.vm as any
+      const row = makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE })
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
+      expect(mocks.apiPost).toHaveBeenCalledWith('/operations/check_contextual.json', expect.any(Object))
+      expect(vm.modalEntry.contextualMatches).toEqual([contextual])
+      expect(vm.modalEntry.loadingContextual).toBe(false)
+    })
+
+    it('excludes existing duplicate ids from the contextual request', async () => {
+      const wrapper = await mountView()
+      const vm = wrapper.vm as any
+      const row = makeRow('Esselunga', { duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE })
+      await vm.openDuplicateModal('operation', row)
+      await flushPromises()
+      const payload = mocks.apiPost.mock.calls[0][1]
+      expect(payload.exclude_ids).toContain(DUPLICATE.id)
     })
   })
 

--- a/app/frontend/__tests__/ImportView.test.ts
+++ b/app/frontend/__tests__/ImportView.test.ts
@@ -196,6 +196,32 @@ describe('ImportView', () => {
       expect(vm.rows[0].selected).toBe(true)
     })
 
+    it('does not re-deselect row on re-check if user already reviewed the probable duplicate', async () => {
+      mocks.apiPost.mockResolvedValue([{ index: 0, matches: [DUPLICATE] }])
+      const wrapper = await mountView()
+      const vm = wrapper.vm as any
+      // Row already has duplicates set (simulates having been through a previous check)
+      vm.rows.push(makeRow('Esselunga', { selected: true, duplicates: [DUPLICATE], selectedDuplicate: DUPLICATE }))
+      // User manually re-selected the row after dismissing the duplicate
+      vm.rows[0].selected = true
+      // A re-check fires (e.g. another row changed)
+      await vm.checkDuplicates()
+      await nextTick()
+      expect(vm.rows[0].selected).toBe(true)
+    })
+
+    it('preserves selectedDuplicate across re-checks when the same match is still returned', async () => {
+      const alt: DuplicateMatch = { ...DUPLICATE, id: 99 }
+      mocks.apiPost.mockResolvedValue([{ index: 0, matches: [DUPLICATE, alt] }])
+      const wrapper = await mountView()
+      const vm = wrapper.vm as any
+      // Row already reviewed: user had chosen alt (id=99) instead of the probable (id=77)
+      vm.rows.push(makeRow('Esselunga', { duplicates: [DUPLICATE, alt], selectedDuplicate: alt }))
+      await vm.checkDuplicates()
+      await nextTick()
+      expect(vm.rows[0].selectedDuplicate?.id).toBe(99)
+    })
+
     it('includes skippedRows in the duplicate check payload', async () => {
       const wrapper = await mountView()
       const vm = wrapper.vm as any

--- a/app/frontend/views/operations/ImportView.vue
+++ b/app/frontend/views/operations/ImportView.vue
@@ -309,6 +309,10 @@ async function checkDuplicates(triggeringRow?: Row) {
 
   if (!eligible.length) return
 
+  // Capture state before reset: first-time detection and user's current selection
+  const firstTimeCheck = new Set(eligible.filter(e => e.row.duplicates === null).map(e => e.row))
+  const prevSelected = new Map(eligible.map(e => [e.row, e.row.selectedDuplicate]))
+
   if (triggeringRow) triggeringRow.checkingDuplicates = true
   try {
     const payload = eligible.map(({ row }) => ({
@@ -350,11 +354,13 @@ async function checkDuplicates(triggeringRow?: Row) {
       const entry = eligible[index]
       if (!entry) return
       const targetArray = entry.source === 'rows' ? rows.value : skippedRows.value
-      targetArray[entry.i].duplicates = matches
-      targetArray[entry.i].selectedDuplicate =
-        matches.find(m => m.kind === 'probable') ?? matches[0] ?? null
-      if (entry.source === 'rows' && matches.some(m => m.kind === 'probable'))
-        targetArray[entry.i].selected = false
+      const row = targetArray[entry.i]
+      row.duplicates = matches
+      const prev = prevSelected.get(entry.row)
+      const preserved = prev ? matches.find(m => m.id === prev.id) : null
+      row.selectedDuplicate = preserved ?? matches.find(m => m.kind === 'probable') ?? matches[0] ?? null
+      if (entry.source === 'rows' && matches.some(m => m.kind === 'probable') && firstTimeCheck.has(entry.row))
+        row.selected = false
     })
   } catch {
     // silently ignore duplicate check errors
@@ -369,6 +375,9 @@ async function checkWithdrawalDuplicates(triggeringRow?: WithdrawalRow) {
     .filter(({ row }) => row.date && row.amount && !row.updateExisting)
 
   if (!eligible.length) return
+
+  const firstTimeCheck = new Set(eligible.filter(e => e.row.duplicates === null).map(e => e.row))
+  const prevSelected = new Map(eligible.map(e => [e.row, e.row.selectedDuplicate]))
 
   if (triggeringRow) triggeringRow.checkingDuplicates = true
   try {
@@ -399,14 +408,15 @@ async function checkWithdrawalDuplicates(triggeringRow?: WithdrawalRow) {
     })
 
     results.forEach(({ index, matches }) => {
-      const realIndex = eligible[index]?.i
-      if (realIndex !== undefined) {
-        withdrawalRows.value[realIndex].duplicates = matches
-        withdrawalRows.value[realIndex].selectedDuplicate =
-          matches.find(m => m.kind === 'probable') ?? matches[0] ?? null
-        if (matches.some(m => m.kind === 'probable'))
-          withdrawalRows.value[realIndex].selected = false
-      }
+      const entry = eligible[index]
+      if (!entry) return
+      const row = withdrawalRows.value[entry.i]
+      row.duplicates = matches
+      const prev = prevSelected.get(entry.row)
+      const preserved = prev ? matches.find(m => m.id === prev.id) : null
+      row.selectedDuplicate = preserved ?? matches.find(m => m.kind === 'probable') ?? matches[0] ?? null
+      if (matches.some(m => m.kind === 'probable') && firstTimeCheck.has(entry.row))
+        row.selected = false
     })
   } catch {
     // silently ignore

--- a/app/frontend/views/operations/ImportView.vue
+++ b/app/frontend/views/operations/ImportView.vue
@@ -337,7 +337,7 @@ async function checkDuplicates(triggeringRow?: Row) {
     rows.value.forEach(r => {
       if (r.duplicates !== null && !r.updateExisting) {
         if (modalEntry.value?.row === r && !rowsWithNewMatches.has(r)) closeDuplicateModal()
-        if (r.duplicates.some(d => d.kind === 'probable')) r.selected = true
+        if (r.duplicates.some(d => d.kind === 'probable') && !rowsWithNewMatches.has(r)) r.selected = true
         r.duplicates = null
         r.selectedDuplicate = null
       }
@@ -401,7 +401,7 @@ async function checkWithdrawalDuplicates(triggeringRow?: WithdrawalRow) {
     withdrawalRows.value.forEach(r => {
       if (r.duplicates !== null && !r.updateExisting) {
         if (modalEntry.value?.row === r && !rowsWithNewMatches.has(r)) closeDuplicateModal()
-        if (r.duplicates.some(d => d.kind === 'probable')) r.selected = true
+        if (r.duplicates.some(d => d.kind === 'probable') && !rowsWithNewMatches.has(r)) r.selected = true
         r.duplicates = null
         r.selectedDuplicate = null
       }

--- a/app/frontend/views/operations/ImportView.vue
+++ b/app/frontend/views/operations/ImportView.vue
@@ -72,14 +72,33 @@ const savedResult = ref<{ operations: SavedOperation[]; withdrawals: SavedWithdr
 
 // ── Duplicate comparison modal ──────────────────────────────────────────────
 type ModalEntry =
-  | { kind: 'operation'; row: Row }
-  | { kind: 'withdrawal'; row: WithdrawalRow }
+  | { kind: 'operation'; row: Row; contextualMatches: DuplicateMatch[] | null; loadingContextual: boolean }
+  | { kind: 'withdrawal'; row: WithdrawalRow; contextualMatches: DuplicateMatch[] | null; loadingContextual: boolean }
 const modalEntry = ref<ModalEntry | null>(null)
 
-function openDuplicateModal(kind: 'operation', row: Row): void
-function openDuplicateModal(kind: 'withdrawal', row: WithdrawalRow): void
-function openDuplicateModal(kind: 'operation' | 'withdrawal', row: Row | WithdrawalRow): void {
-  modalEntry.value = { kind, row } as ModalEntry
+function openDuplicateModal(kind: 'operation', row: Row): Promise<void>
+function openDuplicateModal(kind: 'withdrawal', row: WithdrawalRow): Promise<void>
+async function openDuplicateModal(kind: 'operation' | 'withdrawal', row: Row | WithdrawalRow): Promise<void> {
+  modalEntry.value = { kind, row, contextualMatches: null, loadingContextual: true } as ModalEntry
+  const currentEntry = modalEntry.value
+  try {
+    const endpoint = kind === 'operation'
+      ? '/operations/check_contextual.json'
+      : '/withdrawals/check_contextual.json'
+    const payload: Record<string, unknown> = {
+      date: row.date,
+      amount: parseFloat(row.amount),
+      note: row.note,
+    }
+    if (kind === 'operation') payload.type_id = (row as Row).typeId
+    const excludeIds = (row.duplicates ?? []).map(d => d.id)
+    const result: DuplicateMatch[] = await api.post(endpoint, { row: payload, exclude_ids: excludeIds })
+    if (modalEntry.value === currentEntry) currentEntry.contextualMatches = result ?? []
+  } catch {
+    if (modalEntry.value === currentEntry) currentEntry.contextualMatches = []
+  } finally {
+    if (modalEntry.value === currentEntry) currentEntry.loadingContextual = false
+  }
 }
 function closeDuplicateModal() { modalEntry.value = null }
 
@@ -333,7 +352,7 @@ async function checkDuplicates(triggeringRow?: Row) {
       const targetArray = entry.source === 'rows' ? rows.value : skippedRows.value
       targetArray[entry.i].duplicates = matches
       targetArray[entry.i].selectedDuplicate =
-        matches.find(m => m.kind === 'probable') ?? matches.find(m => m.kind === 'possible') ?? null
+        matches.find(m => m.kind === 'probable') ?? matches[0] ?? null
       if (entry.source === 'rows' && matches.some(m => m.kind === 'probable'))
         targetArray[entry.i].selected = false
     })
@@ -731,7 +750,7 @@ defineExpose({
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(row, i) in rows" :key="i" :class="{ 'table-warning': row.duplicates?.some(d => d.kind === 'probable'), 'table-info': row.duplicates?.some(d => d.kind === 'possible') && !row.duplicates?.some(d => d.kind === 'probable'), 'opacity-50': !row.selected }">
+              <tr v-for="(row, i) in rows" :key="i" :class="{ 'table-success': row.updateExisting, 'table-warning': !row.updateExisting && row.duplicates?.some(d => d.kind === 'probable'), 'table-info': !row.updateExisting && row.duplicates?.some(d => d.kind === 'possible') && !row.duplicates?.some(d => d.kind === 'probable'), 'opacity-50': !row.selected }">
                 <td class="text-center">
                   <input type="checkbox" class="form-check-input" v-model="row.selected" />
                 </td>
@@ -759,17 +778,20 @@ defineExpose({
                     <option :value="null">—</option>
                     <option v-for="t in types" :key="t.id" :value="t.id">{{ t.name }}</option>
                   </select>
-                  <small v-if="row.duplicates?.length" class="d-block mt-1 d-flex align-items-center gap-2 flex-wrap">
-                    <template v-if="row.duplicates.some(d => d.kind !== 'contextual')">
-                      <span :class="row.duplicates.some(d => d.kind === 'probable') ? 'badge bg-warning text-dark' : 'badge bg-info text-dark'">
-                        {{ row.duplicates.some(d => d.kind === 'probable') ? 'Probabile duplicato' : 'Da verificare' }}
-                        <span v-if="row.duplicates.filter(d => d.kind !== 'contextual').length > 1"> ({{ row.duplicates.filter(d => d.kind !== 'contextual').length }})</span>
+                  <small v-if="row.date" class="d-block mt-1 d-flex align-items-center gap-2 flex-wrap">
+                    <template v-if="row.duplicates?.length || row.selectedDuplicate">
+                      <span v-if="row.duplicates?.some(d => d.kind === 'probable')" class="badge bg-warning text-dark">
+                        Probabile duplicato<span v-if="row.duplicates!.length > 1"> ({{ row.duplicates!.length }})</span>
                       </span>
+                      <span v-else-if="row.duplicates?.length" class="badge bg-info text-dark">
+                        Da verificare<span v-if="row.duplicates!.length > 1"> ({{ row.duplicates!.length }})</span>
+                      </span>
+                      <span v-else class="badge bg-secondary">Collegato</span>
                       <span class="text-muted">€{{ row.selectedDuplicate?.amount }} – {{ row.selectedDuplicate?.note }}</span>
                     </template>
                     <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
                       :disabled="row.checkingDuplicates" @click="openDuplicateModal('operation', row)">Confronta</button>
-                    <label v-if="row.duplicates.some(d => d.kind !== 'contextual')" class="d-inline-flex align-items-center gap-1">
+                    <label v-if="row.duplicates?.length || row.selectedDuplicate" class="d-inline-flex align-items-center gap-1">
                       <input type="checkbox" class="form-check-input"
                         v-model="row.updateExisting"
                         @change="onOpUpdateExistingChange(row)" />
@@ -811,7 +833,7 @@ defineExpose({
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(row, i) in withdrawalRows" :key="i" :class="{ 'table-warning': row.duplicates?.some(d => d.kind === 'probable'), 'table-info': row.duplicates?.some(d => d.kind === 'possible') && !row.duplicates?.some(d => d.kind === 'probable'), 'opacity-50': !row.selected }">
+              <tr v-for="(row, i) in withdrawalRows" :key="i" :class="{ 'table-success': row.updateExisting, 'table-warning': !row.updateExisting && row.duplicates?.some(d => d.kind === 'probable'), 'table-info': !row.updateExisting && row.duplicates?.some(d => d.kind === 'possible') && !row.duplicates?.some(d => d.kind === 'probable'), 'opacity-50': !row.selected }">
                 <td class="text-center">
                   <input type="checkbox" class="form-check-input" v-model="row.selected" />
                 </td>
@@ -826,17 +848,20 @@ defineExpose({
                 <td>
                   <input v-model="row.note" type="text" class="form-control form-control-sm"
                     @change="() => scheduleWithdrawalDuplicatesCheck(row)" />
-                  <small v-if="row.duplicates?.length" class="d-block mt-1 d-flex align-items-center gap-2 flex-wrap">
-                    <template v-if="row.duplicates.some(d => d.kind !== 'contextual')">
-                      <span :class="row.duplicates.some(d => d.kind === 'probable') ? 'badge bg-warning text-dark' : 'badge bg-info text-dark'">
-                        {{ row.duplicates.some(d => d.kind === 'probable') ? 'Probabile duplicato' : 'Da verificare' }}
-                        <span v-if="row.duplicates.filter(d => d.kind !== 'contextual').length > 1"> ({{ row.duplicates.filter(d => d.kind !== 'contextual').length }})</span>
+                  <small v-if="row.date" class="d-block mt-1 d-flex align-items-center gap-2 flex-wrap">
+                    <template v-if="row.duplicates?.length || row.selectedDuplicate">
+                      <span v-if="row.duplicates?.some(d => d.kind === 'probable')" class="badge bg-warning text-dark">
+                        Probabile duplicato<span v-if="row.duplicates!.length > 1"> ({{ row.duplicates!.length }})</span>
                       </span>
+                      <span v-else-if="row.duplicates?.length" class="badge bg-info text-dark">
+                        Da verificare<span v-if="row.duplicates!.length > 1"> ({{ row.duplicates!.length }})</span>
+                      </span>
+                      <span v-else class="badge bg-secondary">Collegato</span>
                       <span class="text-muted">€{{ row.selectedDuplicate?.amount }} – {{ row.selectedDuplicate?.note }}</span>
                     </template>
                     <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
                       :disabled="row.checkingDuplicates" @click="openDuplicateModal('withdrawal', row)">Confronta</button>
-                    <label v-if="row.duplicates.some(d => d.kind !== 'contextual')" class="d-inline-flex align-items-center gap-1">
+                    <label v-if="row.duplicates?.length || row.selectedDuplicate" class="d-inline-flex align-items-center gap-1">
                       <input type="checkbox" class="form-check-input"
                         v-model="row.updateExisting"
                         @change="onWdUpdateExistingChange(row)" />
@@ -896,7 +921,7 @@ defineExpose({
               </tr>
             </thead>
             <tbody>
-              <tr v-for="(row, i) in skippedRows" :key="i" :class="{ 'table-warning': row.duplicates?.some(d => d.kind === 'probable'), 'table-info': row.duplicates?.some(d => d.kind === 'possible') && !row.duplicates?.some(d => d.kind === 'probable'), 'opacity-50': !row.selected }">
+              <tr v-for="(row, i) in skippedRows" :key="i" :class="{ 'table-success': row.updateExisting, 'table-warning': !row.updateExisting && row.duplicates?.some(d => d.kind === 'probable'), 'table-info': !row.updateExisting && row.duplicates?.some(d => d.kind === 'possible') && !row.duplicates?.some(d => d.kind === 'probable'), 'opacity-50': !row.selected }">
                 <td class="text-center">
                   <input type="checkbox" class="form-check-input" v-model="row.selected" />
                 </td>
@@ -924,17 +949,20 @@ defineExpose({
                     <option :value="null">—</option>
                     <option v-for="t in types" :key="t.id" :value="t.id">{{ t.name }}</option>
                   </select>
-                  <small v-if="row.duplicates?.length" class="d-block mt-1 d-flex align-items-center gap-2 flex-wrap">
-                    <template v-if="row.duplicates.some(d => d.kind !== 'contextual')">
-                      <span :class="row.duplicates.some(d => d.kind === 'probable') ? 'badge bg-warning text-dark' : 'badge bg-info text-dark'">
-                        {{ row.duplicates.some(d => d.kind === 'probable') ? 'Probabile duplicato' : 'Da verificare' }}
-                        <span v-if="row.duplicates.filter(d => d.kind !== 'contextual').length > 1"> ({{ row.duplicates.filter(d => d.kind !== 'contextual').length }})</span>
+                  <small v-if="row.date" class="d-block mt-1 d-flex align-items-center gap-2 flex-wrap">
+                    <template v-if="row.duplicates?.length || row.selectedDuplicate">
+                      <span v-if="row.duplicates?.some(d => d.kind === 'probable')" class="badge bg-warning text-dark">
+                        Probabile duplicato<span v-if="row.duplicates!.length > 1"> ({{ row.duplicates!.length }})</span>
                       </span>
+                      <span v-else-if="row.duplicates?.length" class="badge bg-info text-dark">
+                        Da verificare<span v-if="row.duplicates!.length > 1"> ({{ row.duplicates!.length }})</span>
+                      </span>
+                      <span v-else class="badge bg-secondary">Collegato</span>
                       <span class="text-muted">€{{ row.selectedDuplicate?.amount }} – {{ row.selectedDuplicate?.note }}</span>
                     </template>
                     <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
                       :disabled="row.checkingDuplicates" @click="openDuplicateModal('operation', row)">Confronta</button>
-                    <label v-if="row.duplicates.some(d => d.kind !== 'contextual')" class="d-inline-flex align-items-center gap-1">
+                    <label v-if="row.duplicates?.length || row.selectedDuplicate" class="d-inline-flex align-items-center gap-1">
                       <input type="checkbox" class="form-check-input"
                         v-model="row.updateExisting"
                         @change="onOpUpdateExistingChange(row)" />
@@ -1034,12 +1062,11 @@ defineExpose({
           <div class="modal-content">
             <div class="modal-header">
               <h5 class="modal-title">
-                <template v-if="modalEntry.row.duplicates?.some(d => d.kind !== 'contextual')">
-                  <span :class="(modalEntry.row.duplicates?.some(d => d.kind === 'probable') ?? false) ? 'badge bg-warning text-dark me-2' : 'badge bg-info text-dark me-2'">
-                    {{ (modalEntry.row.duplicates?.some(d => d.kind === 'probable') ?? false) ? 'Probabile duplicato' : 'Da verificare' }}
-                  </span>
-                </template>
-                Confronto — {{ (modalEntry.row.duplicates?.length ?? 0) }} {{ (modalEntry.row.duplicates?.length ?? 0) === 1 ? 'record trovato' : 'record trovati' }}
+                <span v-if="modalEntry.row.duplicates?.length"
+                  :class="(modalEntry.row.duplicates?.some(d => d.kind === 'probable') ?? false) ? 'badge bg-warning text-dark me-2' : 'badge bg-info text-dark me-2'">
+                  {{ (modalEntry.row.duplicates?.some(d => d.kind === 'probable') ?? false) ? 'Probabile duplicato' : 'Da verificare' }}
+                </span>
+                Confronto — {{ (modalEntry.row.duplicates?.length ?? 0) + (modalEntry.contextualMatches?.length ?? 0) }} {{ ((modalEntry.row.duplicates?.length ?? 0) + (modalEntry.contextualMatches?.length ?? 0)) === 1 ? 'record trovato' : 'record trovati' }}
               </h5>
               <button type="button" class="btn-close" @click="closeDuplicateModal"></button>
             </div>
@@ -1105,6 +1132,30 @@ defineExpose({
                       <span v-else-if="m.kind === 'possible'" class="badge bg-info text-dark">Possibile</span>
                       <span v-else class="badge bg-secondary">Stesso mese</span>
                     </td>
+                    <td>{{ m.date }}</td>
+                    <td>
+                      <span v-if="m.sign" :class="m.sign === '-' ? 'text-danger' : 'text-success'">
+                        {{ m.sign === '-' ? '−' : '+' }}€{{ m.amount }}
+                      </span>
+                      <span v-else class="text-danger">−€{{ m.amount }}</span>
+                    </td>
+                    <td>{{ m.note }}</td>
+                    <td v-if="modalEntry.kind === 'operation'">{{ m.type_name ?? '—' }}</td>
+                    <td>{{ m.user_name ?? '—' }}</td>
+                  </tr>
+                  <tr v-if="modalEntry.loadingContextual">
+                    <td :colspan="modalEntry.kind === 'operation' ? 7 : 6" class="text-center text-muted small py-2">
+                      <span class="spinner-border spinner-border-sm me-1"></span>Ricerca nel mese in corso…
+                    </td>
+                  </tr>
+                  <tr v-for="m in (modalEntry.contextualMatches ?? [])" :key="'ctx-' + m.id">
+                    <td class="text-center">
+                      <input type="radio"
+                        class="form-check-input"
+                        :checked="modalEntry.row.selectedDuplicate?.id === m.id && modalEntry.row.updateExisting"
+                        @change="selectDuplicate(m)" />
+                    </td>
+                    <td><span class="badge bg-secondary">Stesso mese</span></td>
                     <td>{{ m.date }}</td>
                     <td>
                       <span v-if="m.sign" :class="m.sign === '-' ? 'text-danger' : 'text-success'">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       get '/all' => 'withdrawals#all', :as => :all
       get '/archive' => 'withdrawals#archive', :as => :archive
       post 'check_duplicates'
+      post 'check_contextual'
     end
   end
   resources :types
@@ -16,6 +17,7 @@ Rails.application.routes.draw do
       post 'bulk'
       post 'extract'
       post 'check_duplicates'
+      post 'check_contextual'
     end
   end
   resources :users , except: :destroy

--- a/test/controllers/operations_controller_test.rb
+++ b/test/controllers/operations_controller_test.rb
@@ -198,14 +198,12 @@ class OperationsControllerTest < ActionDispatch::IntegrationTest
     assert json[0]['matches'].any? { |m| m['kind'] == 'probable' }
   end
 
-  test "check_duplicates returns only contextual when same category but amount differs by more than 2.00 and no note" do
+  test "check_duplicates returns empty when same category but amount differs by more than 2.00 and no note" do
     post check_duplicates_operations_path, params: {
       rows: [{ date: @operation.date, amount: @operation.amount.to_f + 3.00, type_id: @operation.type_id }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
   test "check_duplicates returns empty when amount within 2.00 but no category and no note" do
@@ -291,26 +289,22 @@ class OperationsControllerTest < ActionDispatch::IntegrationTest
     assert_empty JSON.parse(response.body)
   end
 
-  test "check_duplicates returns only contextual when date differs by 3 or more days" do
+  test "check_duplicates returns empty when date differs by 3 or more days" do
     far_date = @operation.date + 3.days
     post check_duplicates_operations_path, params: {
       rows: [{ date: far_date, amount: @operation.amount, type_id: @operation.type_id }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
-  test "check_duplicates returns only contextual when import date is before existing record" do
+  test "check_duplicates returns empty when import date is before existing record" do
     prior_date = @operation.date - 1.day
     post check_duplicates_operations_path, params: {
       rows: [{ date: prior_date, amount: @operation.amount, type_id: @operation.type_id }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
   test "check_duplicates returns kind=possible for amount within 2.00 and similar note" do
@@ -323,24 +317,22 @@ class OperationsControllerTest < ActionDispatch::IntegrationTest
     assert json[0]['matches'].any? { |m| m['kind'] == 'possible' }
   end
 
-  test "check_duplicates returns only contextual when note matches but amount differs by more than 2.00" do
+  test "check_duplicates returns empty when note matches but amount differs by more than 2.00" do
     post check_duplicates_operations_path, params: {
       rows: [{ date: @operation.date, amount: @operation.amount.to_f + 50, note: 'Esselunga' }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
-  test "check_duplicates returns contextual matches sorted last after probable and possible" do
+  test "check_duplicates returns probable before possible in sort order" do
     post check_duplicates_operations_path, params: {
       rows: [{ date: @operation.date, amount: @operation.amount, type_id: @operation.type_id, note: 'Esselunga' }]
     }, headers: @headers, as: :json
     assert_response :success
     json = JSON.parse(response.body)
     kinds = json[0]['matches'].map { |m| m['kind'] }
-    kind_order = { 'probable' => 0, 'possible' => 1, 'contextual' => 2 }
+    kind_order = { 'probable' => 0, 'possible' => 1 }
     assert_equal kinds, kinds.sort_by { |k| kind_order.fetch(k, 99) }
   end
 
@@ -400,5 +392,51 @@ class OperationsControllerTest < ActionDispatch::IntegrationTest
         ]
       }, headers: @headers, as: :json
     end
+  end
+
+  test "check_contextual returns match for same month and same amount" do
+    post check_contextual_operations_path, params: {
+      row: { date: '2016-06-01', amount: @operation.amount }
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.any? { |m| m['id'] == @operation.id }
+    assert json.all? { |m| m['kind'] == 'contextual' }
+  end
+
+  test "check_contextual returns match for same month by type_id" do
+    post check_contextual_operations_path, params: {
+      row: { date: '2016-06-01', amount: 9999, type_id: @operation.type_id }
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.any? { |m| m['id'] == @operation.id }
+  end
+
+  test "check_contextual returns match for same month by note similarity" do
+    post check_contextual_operations_path, params: {
+      row: { date: '2016-06-01', amount: 9999, note: 'Esselunga' }
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.any? { |m| m['id'] == @operation.id }
+  end
+
+  test "check_contextual returns empty for different month" do
+    post check_contextual_operations_path, params: {
+      row: { date: '2016-07-01', amount: @operation.amount }
+    }, headers: @headers, as: :json
+    assert_response :success
+    assert_empty JSON.parse(response.body)
+  end
+
+  test "check_contextual respects exclude_ids" do
+    post check_contextual_operations_path, params: {
+      row: { date: '2016-06-01', amount: @operation.amount },
+      exclude_ids: [@operation.id]
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.none? { |m| m['id'] == @operation.id }
   end
 end

--- a/test/controllers/withdrawals_controller_test.rb
+++ b/test/controllers/withdrawals_controller_test.rb
@@ -113,26 +113,22 @@ class WithdrawalsControllerTest < ActionDispatch::IntegrationTest
     assert json[0]['matches'].any? { |m| m['kind'] == 'possible' }
   end
 
-  test "check_duplicates returns only contextual when date differs by 3 or more days" do
+  test "check_duplicates returns empty when date differs by 3 or more days" do
     far_date = @withdrawal.date + 3.days
     post check_duplicates_withdrawals_path, params: {
       rows: [{ date: far_date, amount: @withdrawal.amount }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
-  test "check_duplicates returns only contextual when import date is before existing record" do
+  test "check_duplicates returns empty when import date is before existing record" do
     prior_date = @withdrawal.date - 1.day
     post check_duplicates_withdrawals_path, params: {
       rows: [{ date: prior_date, amount: @withdrawal.amount }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
   test "check_duplicates returns empty when amount differs by more than 2.00 and no note" do
@@ -155,14 +151,12 @@ class WithdrawalsControllerTest < ActionDispatch::IntegrationTest
     assert json[0]['matches'].first.key?('note')
   end
 
-  test "check_duplicates returns only contextual when note matches but amount differs by more than 2.00" do
+  test "check_duplicates returns empty when note matches but amount differs by more than 2.00" do
     post check_duplicates_withdrawals_path, params: {
       rows: [{ date: @withdrawal.date, amount: 9999, note: 'clacla' }]
     }, headers: @headers, as: :json
     assert_response :success
-    json = JSON.parse(response.body)
-    assert_equal 1, json.length
-    assert json[0]['matches'].all? { |m| m['kind'] == 'contextual' }
+    assert_empty JSON.parse(response.body)
   end
 
   test "check_duplicates returns user_name in match response" do
@@ -172,5 +166,42 @@ class WithdrawalsControllerTest < ActionDispatch::IntegrationTest
     json = JSON.parse(response.body)
     assert json[0]['matches'].first.key?('user_name')
     assert_not_nil json[0]['matches'].first['user_name']
+  end
+
+  test "check_contextual returns match for same month and same amount" do
+    post check_contextual_withdrawals_path, params: {
+      row: { date: '2018-03-01', amount: @withdrawal.amount }
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.any? { |m| m['id'] == @withdrawal.id }
+    assert json.all? { |m| m['kind'] == 'contextual' }
+  end
+
+  test "check_contextual returns match for same month by note similarity" do
+    post check_contextual_withdrawals_path, params: {
+      row: { date: '2018-03-01', amount: 9999, note: 'clacla' }
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.any? { |m| m['id'] == @withdrawal.id }
+  end
+
+  test "check_contextual returns empty for different month" do
+    post check_contextual_withdrawals_path, params: {
+      row: { date: '2018-04-01', amount: @withdrawal.amount }
+    }, headers: @headers, as: :json
+    assert_response :success
+    assert_empty JSON.parse(response.body)
+  end
+
+  test "check_contextual respects exclude_ids" do
+    post check_contextual_withdrawals_path, params: {
+      row: { date: '2018-03-01', amount: @withdrawal.amount },
+      exclude_ids: [@withdrawal.id]
+    }, headers: @headers, as: :json
+    assert_response :success
+    json = JSON.parse(response.body)
+    assert json.none? { |m| m['id'] == @withdrawal.id }
   end
 end


### PR DESCRIPTION
## Summary

- **Level-3 contextual duplicate detection**: same-month matches loaded lazily when the comparison modal opens (spinner + "Stesso mese" badge)
- **REGEXP word-boundary fix**: note similarity matching now uses `REGEXP '[[:<:]]key[[:>:]]'` instead of `LIKE '%key%'` to avoid substring false positives (e.g. "ITALIA" no longer matches "italiani")
- **Fix**: Confronta button always visible when a row has a date — was incorrectly gated on `row.amount` too
- **Fix**: row highlights green (`table-success`) when `updateExisting` is set, even when only contextual matches exist

## Test plan

- [ ] Import rows with probable/possible/contextual duplicates and verify badge colours
- [ ] Open comparison modal → contextual section loads after spinner
- [ ] Select a contextual match → row turns green, "aggiorna" checkbox appears
- [ ] Verify Confronta button appears for rows without an amount
- [ ] `docker-compose run web bin/rails test`
- [ ] `docker-compose run web yarn test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)