### PR TITLE
Add floating action button and fix mobile navbar (#88)

### DIFF
--- a/app/frontend/App.vue
+++ b/app/frontend/App.vue
@@ -10,6 +10,7 @@ const route = useRoute()
 const auth = useAuthStore()
 const opsStore = useOperationsStore()
 const openMenu = ref<string | null>(null)
+const navOpen = ref(false)
 
 const years = computed(() =>
   [...opsStore.maxByYear].map((e) => e.year).sort((a, b) => b - a),
@@ -21,6 +22,7 @@ function toggle(menu: string) {
 
 function close() {
   openMenu.value = null
+  navOpen.value = false
 }
 
 onMounted(async () => {
@@ -48,70 +50,85 @@ watch(
     <nav v-if="auth.isAuthenticated" class="navbar navbar-expand-lg navbar-light bg-light mb-3 px-2">
       <router-link to="/" class="navbar-brand" @click="close">Bilancio</router-link>
 
-      <div class="navbar-nav me-auto flex-wrap">
+      <button class="navbar-toggler ms-auto" type="button" @click.stop="navOpen = !navOpen; openMenu = null">
+        <span class="navbar-toggler-icon"></span>
+      </button>
 
-        <!-- Utenti -->
-        <div class="nav-item dropdown" :class="{ show: openMenu === 'users' }">
-          <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('users')">Utenti</a>
-          <div class="dropdown-menu" :class="{ show: openMenu === 'users' }">
-            <router-link to="/users" class="dropdown-item" @click="close">Lista</router-link>
-            <router-link to="/users/new" class="dropdown-item" @click="close">Nuovo utente</router-link>
+      <div class="collapse navbar-collapse" :class="{ show: navOpen }">
+        <div class="navbar-nav me-auto">
+
+          <!-- Utenti -->
+          <div class="nav-item dropdown" :class="{ show: openMenu === 'users' }">
+            <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('users')">Utenti</a>
+            <div class="dropdown-menu" :class="{ show: openMenu === 'users' }">
+              <router-link to="/users" class="dropdown-item" @click="close">Lista</router-link>
+              <router-link to="/users/new" class="dropdown-item" @click="close">Nuovo utente</router-link>
+            </div>
           </div>
+
+          <!-- Operazioni -->
+          <div class="nav-item dropdown" :class="{ show: openMenu === 'ops' }">
+            <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('ops')">Operazioni</a>
+            <div class="dropdown-menu" :class="{ show: openMenu === 'ops' }">
+              <router-link to="/operations" class="dropdown-item" @click="close">Lista</router-link>
+              <router-link to="/operations/new" class="dropdown-item" @click="close">Nuova operazione</router-link>
+              <router-link to="/operations/import" class="dropdown-item" @click="close">Importa da estratto conto</router-link>
+            </div>
+          </div>
+
+          <!-- Categorie -->
+          <div class="nav-item dropdown" :class="{ show: openMenu === 'types' }">
+            <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('types')">Categorie</a>
+            <div class="dropdown-menu" :class="{ show: openMenu === 'types' }">
+              <router-link to="/types" class="dropdown-item" @click="close">Lista</router-link>
+              <router-link to="/types/new" class="dropdown-item" @click="close">Nuova categoria</router-link>
+            </div>
+          </div>
+
+          <!-- Prelievi -->
+          <div class="nav-item dropdown" :class="{ show: openMenu === 'withdrawals' }">
+            <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('withdrawals')">Prelievi</a>
+            <div class="dropdown-menu" :class="{ show: openMenu === 'withdrawals' }">
+              <router-link to="/withdrawals" class="dropdown-item" @click="close">Lista</router-link>
+              <router-link to="/withdrawals/all" class="dropdown-item" @click="close">Tutti</router-link>
+              <router-link to="/withdrawals/archive" class="dropdown-item" @click="close">Archivio</router-link>
+              <div class="dropdown-divider"></div>
+              <router-link to="/withdrawals/new" class="dropdown-item" @click="close">Nuovo prelievo</router-link>
+            </div>
+          </div>
+
+          <!-- Anno -->
+          <div class="nav-item dropdown" :class="{ show: openMenu === 'year' }">
+            <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('year')">Anno</a>
+            <div class="dropdown-menu" :class="{ show: openMenu === 'year' }">
+              <router-link
+                v-for="y in years"
+                :key="y"
+                :to="`/operations/year/${y}`"
+                class="dropdown-item"
+                @click="close"
+              >{{ y }}</router-link>
+            </div>
+          </div>
+
         </div>
 
-        <!-- Operazioni -->
-        <div class="nav-item dropdown" :class="{ show: openMenu === 'ops' }">
-          <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('ops')">Operazioni</a>
-          <div class="dropdown-menu" :class="{ show: openMenu === 'ops' }">
-            <router-link to="/operations" class="dropdown-item" @click="close">Lista</router-link>
-            <router-link to="/operations/new" class="dropdown-item" @click="close">Nuova operazione</router-link>
-            <router-link to="/operations/import" class="dropdown-item" @click="close">Importa da estratto conto</router-link>
-          </div>
+        <div class="navbar-nav">
+          <span class="nav-link text-muted">{{ auth.currentUser?.name }}</span>
+          <router-link to="/logout" class="nav-link text-danger" @click="close">Esci</router-link>
         </div>
-
-        <!-- Categorie -->
-        <div class="nav-item dropdown" :class="{ show: openMenu === 'types' }">
-          <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('types')">Categorie</a>
-          <div class="dropdown-menu" :class="{ show: openMenu === 'types' }">
-            <router-link to="/types" class="dropdown-item" @click="close">Lista</router-link>
-            <router-link to="/types/new" class="dropdown-item" @click="close">Nuova categoria</router-link>
-          </div>
-        </div>
-
-        <!-- Prelievi -->
-        <div class="nav-item dropdown" :class="{ show: openMenu === 'withdrawals' }">
-          <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('withdrawals')">Prelievi</a>
-          <div class="dropdown-menu" :class="{ show: openMenu === 'withdrawals' }">
-            <router-link to="/withdrawals" class="dropdown-item" @click="close">Lista</router-link>
-            <router-link to="/withdrawals/all" class="dropdown-item" @click="close">Tutti</router-link>
-            <router-link to="/withdrawals/archive" class="dropdown-item" @click="close">Archivio</router-link>
-            <div class="dropdown-divider"></div>
-            <router-link to="/withdrawals/new" class="dropdown-item" @click="close">Nuovo prelievo</router-link>
-          </div>
-        </div>
-
-        <!-- Anno -->
-        <div class="nav-item dropdown" :class="{ show: openMenu === 'year' }">
-          <a class="nav-link dropdown-toggle" href="#" @click.prevent="toggle('year')">Anno</a>
-          <div class="dropdown-menu" :class="{ show: openMenu === 'year' }">
-            <router-link
-              v-for="y in years"
-              :key="y"
-              :to="`/operations/year/${y}`"
-              class="dropdown-item"
-              @click="close"
-            >{{ y }}</router-link>
-          </div>
-        </div>
-
-      </div>
-
-      <div class="navbar-nav ms-auto">
-        <span class="nav-link text-muted">{{ auth.currentUser?.name }}</span>
-        <router-link to="/logout" class="nav-link text-danger" @click="close">Esci</router-link>
       </div>
     </nav>
 
     <router-view :key="route.fullPath" @click="close" />
+
+    <router-link
+      v-if="auth.isAuthenticated && route.name !== 'operations-new'"
+      to="/operations/new"
+      class="btn btn-primary rounded-circle shadow"
+      style="position:fixed; bottom:1.5rem; right:1.5rem; width:3.5rem; height:3.5rem; font-size:1.75rem; line-height:1; display:flex; align-items:center; justify-content:center; z-index:1040;"
+      title="Nuova operazione"
+      @click="close"
+    >+</router-link>
   </div>
 </template>

--- a/app/frontend/router/index.ts
+++ b/app/frontend/router/index.ts
@@ -36,7 +36,7 @@ export const router = createRouter({
 
     { path: '/', component: HomeView },
     { path: '/operations', component: OperationsList },
-    { path: '/operations/new', component: OperationForm },
+    { path: '/operations/new', name: 'operations-new', component: OperationForm },
     { path: '/operations/import', component: ImportView },
     { path: '/operations/year/:year', component: YearView },
     { path: '/operations/:year(\\d{4})/:month(\\d{1,2})', component: MonthView },


### PR DESCRIPTION
## Summary

- Add a fixed `+` FAB in the bottom-right corner for quick access to `/operations/new` from any page
- Hide the FAB when already on the new operation form to avoid redundancy
- Add a hamburger toggler so the navbar collapses on small screens (Bootstrap 5 CSS-only, no JS import needed)
- Wrap all nav items in a `collapse navbar-collapse` div controlled by Vue `:class="{ show: navOpen }"`

Closes #88

## Test plan

- [ ] Open any page → `+` button visible bottom-right
- [ ] Click `+` → navigates to `/operations/new`
- [ ] On `/operations/new` → FAB not visible
- [ ] On mobile / narrow viewport → hamburger icon visible, nav items hidden
- [ ] Click hamburger → nav items expand
- [ ] Click any nav item → nav closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)