### PR TITLE
fix: update bcrypt to 3.1.22 and unpin exact version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'vite_rails'
 # Build JSON APIs with ease
 gem 'jbuilder'
 # Use ActiveModel has_secure_password
-gem 'bcrypt', '3.1.12'
+gem 'bcrypt', '~> 3.1'
 
 gem 'solid_cache'
 gem 'solid_cable'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     base64 (0.3.0)
-    bcrypt (3.1.12)
+    bcrypt (3.1.22)
     bigdecimal (4.1.2)
     builder (3.3.0)
     byebug (11.1.3)
@@ -243,7 +243,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotaterb
-  bcrypt (= 3.1.12)
+  bcrypt (~> 3.1)
   byebug
   concurrent-ruby (~> 1.0)
   jbuilder


### PR DESCRIPTION
## Summary
- Unpins bcrypt from exact version `3.1.12` to `~> 3.1` to allow patch updates
- Resolves Dependabot alert #93 (bcrypt 3.1.12 → 3.1.22, CVE security fix)

Closes #93