### PR TITLE
fix: address security vulnerabilities in dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'minitest', '~> 5.1'
 gem 'zeitwerk', '~> 2.2'
 gem 'concurrent-ruby', '~> 1.0'
 gem 'mysql2', '~> 0.5'
-gem 'jwt', '~> 2.2'
+gem 'jwt', '~> 3.2'
 gem 'puma', '~> 6.0'
 
 gem 'vite_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.19.4)
-    jwt (2.10.2)
+    jwt (3.2.0)
       base64
     listen (3.10.0)
       logger
@@ -139,9 +139,9 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.2-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     pp (0.6.3)
       prettyprint
@@ -247,7 +247,7 @@ DEPENDENCIES
   byebug
   concurrent-ruby (~> 1.0)
   jbuilder
-  jwt (~> 2.2)
+  jwt (~> 3.2)
   listen
   minitest (~> 5.1)
   mysql2 (~> 0.5)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1975,9 +1975,9 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,10 +932,10 @@ js-beautify@^1.14.9:
     js-cookie "^3.0.5"
     nopt "^7.2.1"
 
-js-cookie@^3.0.5:
-  version "3.0.5"
-  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz"
-  integrity sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==
+js-cookie@3.0.7, js-cookie@^3.0.5:
+  version "3.0.7"
+  resolved "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz#0a53abfc459c8e89c85d7a38eb6cb68714965b8c"
+  integrity sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==
 
 js-tokens@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
## Summary

- **nokogiri** 1.19.2 → 1.19.3: fixes ReDoS in CSS selector tokenizer (GHSA-c4rq-3m3g-8wgx) and memory leak in XSLT transform (GHSA-v2fc-qm4h-8hqv)
- **jwt** 2.10.2 → 3.2.0: fixes CVE-2026-45363 / GHSA-c32j-vqhx-rx3x (nil/empty HMAC keys were silently accepted during sign/verify)
- **js-cookie** 3.0.5 → 3.0.7: fixes CVE-2026-46625 (cookie attribute injection)

Supersedes and closes Dependabot PRs #104, #105, #107.
PR #54 (follow-redirects) is obsolete — the package is no longer present in the current `yarn.lock`.

## Notes on jwt 3.x compatibility

The existing code uses `JWT.encode`/`JWT.decode` with explicit `algorithm: 'HS512'` — both methods remain backward-compatible in jwt 3.x. No application code changes required.

## Test plan

- [x] `bin/rails test` — 154 runs, 345 assertions, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)