### PR TITLE
chore: upgrade actions/checkout from v4 to v5 (Node.js 24)

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -46,7 +46,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: sudo apt-get install -y default-libmysqlclient-dev
@@ -72,7 +72,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -32,7 +32,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: sudo apt-get install -y default-libmysqlclient-dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install system dependencies
         run: sudo apt-get install -y default-libmysqlclient-dev


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from v4 to v5 in all three workflow files (`docker-build.yml`, `pr-gate.yml`, `test.yml`)
- Required before June 2nd, 2026: GitHub Actions will force Node.js 24 by default, deprecating Node.js 20 actions

## Test plan

- [ ] Verify PR Gate workflow passes on this PR